### PR TITLE
Rename internal struct etmCryptor to aeadCryptor

### DIFF
--- a/read.go
+++ b/read.go
@@ -24,7 +24,7 @@ type readStream struct {
 }
 
 // Verify validates the contents of an encrypted input Reader
-func (e *etmCryptor) Verify(r io.ReadSeeker) error {
+func (e *aeadCryptor) Verify(r io.ReadSeeker) error {
 	err := e.Decrypt(r, ioutil.Discard)
 	if err != nil {
 		return err
@@ -38,7 +38,7 @@ func (e *etmCryptor) Verify(r io.ReadSeeker) error {
 
 // Decrypt incrementally decrypts the r into w.  Only authenticated cleartext is emitted, however
 // truncation attacks are possible, so users must ignore all output written to w if an error is returned.
-func (e *etmCryptor) Decrypt(r io.Reader, w io.Writer) error {
+func (e *aeadCryptor) Decrypt(r io.Reader, w io.Writer) error {
 	er := readStream{
 		cipher: e.c,
 		r:      r,

--- a/store_test.go
+++ b/store_test.go
@@ -37,7 +37,7 @@ func TestStore(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Expected no error: %s", err)
 	}
-	ec, ok := c4.(*etmCryptor)
+	ec, ok := c4.(*aeadCryptor)
 	if !ok {
 		t.Fatalf("Expected *etmCryptor: %T", c4)
 	}

--- a/write.go
+++ b/write.go
@@ -25,7 +25,7 @@ type writeStream struct {
 }
 
 // Encrypt writes the contents of r into a w using lfcrypt encrypted format.
-func (e *etmCryptor) Encrypt(r io.Reader, w io.Writer) error {
+func (e *aeadCryptor) Encrypt(r io.Reader, w io.Writer) error {
 	stream, err := e.newWriteStream(r, w)
 	if err != nil {
 		return err
@@ -49,7 +49,7 @@ func (e *etmCryptor) Encrypt(r io.Reader, w io.Writer) error {
 	return nil
 }
 
-func (e *etmCryptor) newWriteStream(r io.Reader, w io.Writer) (*writeStream, error) {
+func (e *aeadCryptor) newWriteStream(r io.Reader, w io.Writer) (*writeStream, error) {
 	stream := &writeStream{
 		key:        keyId{e.keyid},
 		cipherType: e.cipherType,


### PR DESCRIPTION
- Original name was related to the `etm` library, but `aeadCryptor` is really a wrapper around the `crypto.AEAD` interface.  This changes the struct name to make more sense.